### PR TITLE
Add Octomind — open-source CLI agent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ English | [中文](README.zh-CN.md)
 - **[Neovate Code](https://github.com/neovateai/neovate-code)**, Open-source CLI code agent with plugin system and multi-model support
 - **[GitHub Copilot CLI](https://github.com/github/copilot-cli)**, GitHub's terminal-native AI coding assistant with repository integration and agentic capabilities
 
+- [Octomind](https://github.com/muvon/octomind) - Open-source, model-agnostic AI agent runtime with community-built specialist agents (developer, medical, legal, DevOps), MCP support, and zero-config setup.
 ## VS Code Extensions
 
 - **[Cline](https://cline.bot/)**, Autonomous AI agent for VS Code with file editing and web browsing capabilities


### PR DESCRIPTION
## Add Octomind

[Octomind](https://github.com/muvon/octomind) is an open-source (Apache 2.0) AI agent runtime written in Rust.

**Key features:**
- Model-agnostic: 13+ providers (OpenAI, Anthropic, Google, AWS, DeepSeek, etc.)
- Community tap registry: `octomind run developer:rust`, `doctor:blood`, `legal:contracts`
- MCP client with runtime self-extension — agents acquire new tools at runtime
- Infinite sessions via adaptive compression
- Zero config — one command to run any domain specialist

**Website:** https://octomind.run
**GitHub:** https://github.com/muvon/octomind
**License:** Apache 2.0