### PR TITLE
Add Yao Agents to Terminal-Based AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ English | [中文](README.zh-CN.md)
 - **[CodeBuff](https://github.com/CodebuffAI/codebuff)**, Multi-agent AI coding assistant with CLI and SDK for precise codebase editing
 - **[Neovate Code](https://github.com/neovateai/neovate-code)**, Open-source CLI code agent with plugin system and multi-model support
 - **[GitHub Copilot CLI](https://github.com/github/copilot-cli)**, GitHub's terminal-native AI coding assistant with repository integration and agentic capabilities
+- **[Yao Agents](https://yaoagents.com)**, Local-first AI execution platform with 30+ AI experts, autonomous Robot workers, Docker sandbox, and MCP support
 
 ## VS Code Extensions
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,6 +33,7 @@
 - **[CodeBuff](https://github.com/CodebuffAI/codebuff)**，多智能体 AI 编程助手，提供 CLI 和 SDK 进行精确代码库编辑
 - **[Neovate Code](https://github.com/neovateai/neovate-code)**，开源 CLI 代码智能体，具备插件系统和多模型支持
 - **[GitHub Copilot CLI](https://github.com/github/copilot-cli)**，GitHub 的终端原生 AI 编程助手，具备代码库集成和智能体功能
+- **[Yao Agents](https://yaoagents.com)**，本地优先的 AI 执行平台，拥有 30+ 领域 AI 专家和自主 Robot 工作器，支持 Docker 沙盒隔离、MCP 工具扩展和多平台消息接入
 
 ## VS Code 扩展
 


### PR DESCRIPTION
Add [Yao Agents](https://yaoagents.com) — a local-first AI execution platform with 30+ domain AI Experts and autonomous Robot workers. Features Docker sandbox isolation, MCP support, BYOK model configuration, and multi-platform messaging (WeChat/Feishu/DingTalk/Telegram/Discord). Open-source engine at [YaoApp/yao](https://github.com/YaoApp/yao).