### PR TITLE
docs: add Orca to Terminal-Based AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ English | [中文](README.zh-CN.md)
 - **[CodeBuff](https://github.com/CodebuffAI/codebuff)**, Multi-agent AI coding assistant with CLI and SDK for precise codebase editing
 - **[Neovate Code](https://github.com/neovateai/neovate-code)**, Open-source CLI code agent with plugin system and multi-model support
 - **[GitHub Copilot CLI](https://github.com/github/copilot-cli)**, GitHub's terminal-native AI coding assistant with repository integration and agentic capabilities
+- **[Orca](https://github.com/echoVic/blade-deepseek)**, DeepSeek-native Rust terminal agent with OS sandboxing and persistent goal mode
 
 ## VS Code Extensions
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,6 +33,7 @@
 - **[CodeBuff](https://github.com/CodebuffAI/codebuff)**，多智能体 AI 编程助手，提供 CLI 和 SDK 进行精确代码库编辑
 - **[Neovate Code](https://github.com/neovateai/neovate-code)**，开源 CLI 代码智能体，具备插件系统和多模型支持
 - **[GitHub Copilot CLI](https://github.com/github/copilot-cli)**，GitHub 的终端原生 AI 编程助手，具备代码库集成和智能体功能
+- **[Orca](https://github.com/echoVic/blade-deepseek)**，DeepSeek 原生 Rust 终端智能体，具备系统级沙箱和持久化目标模式
 
 ## VS Code 扩展
 


### PR DESCRIPTION
Adds **[Orca](https://github.com/echoVic/blade-deepseek)** — a DeepSeek-native terminal coding agent built in Rust (single binary, MIT).

Per CONTRIBUTING.md:
- Added to the end of *Terminal-Based AI Agents* / *终端AI智能体* in both README.md and README.zh-CN.md
- Description kept concise; zh version uses Chinese punctuation and 盘古之白 spacing
- Link points to the main repository